### PR TITLE
Fix Sidebar Issues

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,19 +6,26 @@ import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { useState } from 'react';
 import { cn } from "@/lib/utils"
+import { AnimatePresence, motion } from "framer-motion"
 
 export default function IndexPage() {
   const [isSidebarOpen, setSidebarOpen] = useState(false);
 
   return (
     <div className="container relative mx-auto min-h-screen w-full px-0">
-      {isSidebarOpen && (
-        <div
-          onClick={() => setSidebarOpen(false)}
-          className="fixed inset-0 z-30 bg-black/50 sm:hidden"
-          aria-hidden="true"
-        />
-      )}
+      <AnimatePresence>
+        {isSidebarOpen && (
+          <motion.div
+            onClick={() => setSidebarOpen(false)}
+            className="fixed inset-0 z-30 bg-black/50 sm:hidden"
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          />
+        )}
+      </AnimatePresence>
       <div className="flex">
       {/* 传递 props */}
         <div

--- a/components/link-content.tsx
+++ b/components/link-content.tsx
@@ -29,7 +29,7 @@ export function LinkContent() {
             </div>
           )
         })}
-        <div className="mb-12">
+        <div id = "contact" className="mb-12">
           <div className="my-4">
             <h1 className="mb-2 text-2xl font-bold text-primary/80 sm:text-3xl">联系我</h1>
           </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
-
-import { cn } from "@/lib/utils"
 import { useConfigStore } from "@/stores"
 
 // 定义 Props 接口
@@ -64,7 +62,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
   const { categories } = useConfigStore()
 
   return (
-    <nav className="after:h-[calc(100vh - 65px)] block min-h-screen w-60 flex-row flex-nowrap bg-gray-50 font-semibold sm:bg-background sm:px-6 sm:pb-6">
+    <nav className="after:h-[calc(100vh-65px)] block min-h-screen w-full sm:w-60 flex-row flex-nowrap bg-background font-semibold sm:bg-background px-4 sm:px-6 sm:pb-6 pt-16 sm:pt-0">
       <div className="mx-6 hidden sm:block">
         <h2 className="h-14 leading-[4rem] text-lg font-semibold tracking-tight">
           网址导航
@@ -109,6 +107,39 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
                       </div>
                     )
                   })}
+                </div>
+                {/* 额外添加“联系我”导航按钮 */}
+                <div
+                  className="relative block cursor-pointer rounded-lg transition-colors ease-in-out"
+                  onClick={() => {
+                    const ele = document.getElementById("contact");
+                    if (ele) {
+                      const elePosition = ele.getBoundingClientRect().top;
+                      const offsetPosition = elePosition + window.scrollY - 99;
+                      window.scrollTo({
+                        top: offsetPosition,
+                        behavior: "smooth"
+                      });
+                    }
+                    if (onLinkClick) onLinkClick();
+                  }}
+                  onMouseEnter={() => setHoveredIndex(-1)}
+                  onMouseLeave={() => setHoveredIndex(null)}
+                >
+                  <AnimatePresence>
+                    {hoveredIndex === -1 && (
+                      <motion.span
+                        className="absolute inset-0 block h-full w-full rounded-lg bg-accent"
+                        layoutId="hoverScrollBackground"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1, transition: { duration: 0.15 } }}
+                        exit={{ opacity: 0, transition: { duration: 0.15, delay: 0.2 } }}
+                      />
+                    )}
+                  </AnimatePresence>
+                  <div className="relative z-10 mb-2 flex items-center gap-2 rounded-r-lg p-2 transition-colors ease-in-out before:transition-colors hover:no-underline sm:border-l-0 sm:pl-6 sm:before:absolute sm:before:left-[-5px] sm:before:top-[2px] sm:before:h-[calc(100%-4px)] sm:before:w-[10px] sm:before:rounded-full sm:before:transition-colors">
+                    <span className="truncate text-sm">联系我</span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -5,7 +5,7 @@ export function SiteFooter() {
         <div className="mx-auto">
           <hr className="border-b-1 mb-4 border-gray-200" />
           <div className="flex flex-wrap items-center justify-center md:justify-between">
-            <div className="w-full px-4 md:w-4/12">
+            <div className="w-full px-4 md:w-auto">
               <div className="mb-2 text-center md:mb-0 md:text-left">
                 <a
                   href="https://www.liwenkai.icu"
@@ -13,7 +13,7 @@ export function SiteFooter() {
                   className="text-blueGray-500 py-1 text-center text-sm font-semibold md:text-left"
                   rel="noreferrer"
                 >
-                  Copyright © 2023 Creative Li WenKai
+                  Copyright © 2023 - present Creative Li WenKai
                 </a>
               </div>
             </div>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
**修复[上一个PR (#5) ](https://github.com/liwenka1/next-web-nav/pull/5)增加的sidebar引出的一些问题：**
- 修复移动端sidebar右侧存在多余的空白padding的问题
- 修复移动端sidebar最顶端的分类被navbar挡住的问题
- 修复移动端sidebar在深色模式的背景问题
- 优化：给sidebar弹出时的背景遮罩添加透明度平滑动画（移动端）
- 优化：给sidebar手动添加了一个“关于我”的跳转（移动端&桌面端）

![image](https://github.com/user-attachments/assets/f6feae3e-488a-4ed8-97fc-11c634438175)
![image](https://github.com/user-attachments/assets/ad40bd31-2f7e-4604-8826-6017d470a190)

**其他优化：**
- 样式统一：设置搜索弹窗在小屏幕下也和宽屏一样为圆角矩形。
- 优化footer在部分宽度的显示：
![image](https://github.com/user-attachments/assets/56078f8d-1713-4956-b1d6-43453e8a8b4b)
